### PR TITLE
Don't make urlencode to LowerCase

### DIFF
--- a/hackbar/theme/js/hackbar-panel.js
+++ b/hackbar/theme/js/hackbar-panel.js
@@ -52,7 +52,7 @@ function getFieldFormData(dataString) {
 }
 
 function urlEncode(inputStr) {
-    return encodeURIComponent(inputStr).toLowerCase();
+    return encodeURIComponent(inputStr);
 }
 
 function jsonBeautify(inputStr) {


### PR DESCRIPTION
For php unserialize hack reason,`O:6:"Shield":1:{s:4:"file";s:8:"pctf.php";}` should be encoded as `O:6:%22Shield%22:1:%7Bs:4:%22file%22;s:8:%22pctf.php%22;%7D` rather than `o:6:%22shield%22:1:%7bs:4:%22file%22;s:8:%22pctf.php%22;%7d`
It doesn't work if 'O' is in lowercase.